### PR TITLE
Add reference to ionos cloud

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,3 +166,12 @@ Changelog
 - 2021.09.20
   
   - Fix #9 Domain not known when using subdomain
+
+
+Related Plugins
+------
+
+It's important to note that this plugin targets IONOS `Domain Name Registration
+<https://www.ionos.com/domains/domain-names>`_ service. 
+If you are using IONOS `Cloud DNS service<https://cloud.ionos.com/network/cloud-dns>`_, 
+there is a different plugin provided by IONOS: https://github.com/ionos-cloud/certbot-dns-ionos-cloud

--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ Changelog
 
 
 Related Plugins
-------
+-----------------
 
 It's important to note that this plugin targets IONOS `Domain Name Registration
 <https://www.ionos.com/domains/domain-names>`_ service. 

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ Changelog
 Related Plugins
 -----------------
 
-It's important to note that this plugin targets IONOS `Domain Name Registration
-<https://www.ionos.com/domains/domain-names>`_ service. 
+It's important to note that this plugin targets IONOS `IONOS Developer DNS API
+<https://developer.hosting.ionos.com/docs/dns>`_. 
 If you are using IONOS `Cloud DNS service<https://cloud.ionos.com/network/cloud-dns>`_, 
 there is a different plugin provided by IONOS: https://github.com/ionos-cloud/certbot-dns-ionos-cloud

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ Changelog
 Related Plugins
 -----------------
 
-It's important to note that this plugin targets IONOS `IONOS Developer DNS API
+It's important to note that this plugin targets `IONOS Developer DNS API
 <https://developer.hosting.ionos.com/docs/dns>`_. 
 If you are using IONOS `Cloud DNS service<https://cloud.ionos.com/network/cloud-dns>`_, 
 there is a different plugin provided by IONOS: https://github.com/ionos-cloud/certbot-dns-ionos-cloud


### PR DESCRIPTION
Hi @helgeerbe, 

IONOS will soon release a certbot plugin for the Cloud DNS services: https://github.com/ionos-cloud/certbot-dns-ionos-cloud, and I wanted to add a brief mention to it here, so that the end users can be informed. I am also adding a mention to this repo in the README of the Cloud plugin. 