### PR TITLE
Continue supporting older versions of Certbot back to 2.9.0

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Run tests
+        run: |
+          python -m certbot_dns_ionos.dns_ionos_test
+
       - name: Build source and wheel distributions
         run: |
           python -m pip install --upgrade pip build twine

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ The file 'domain.tld.ini' must be replaced with the version of the example 'cred
 
 ## Changelog
 
+- 2026.05.06
+  - Continue supporting Certbot 2.9.0 (tested)
 - 2024.11.09
   - Update for Certbot 3.0.0
 - 2024.10.20

--- a/certbot_dns_ionos/dns_ionos_test.py
+++ b/certbot_dns_ionos/dns_ionos_test.py
@@ -22,9 +22,9 @@ class AuthenticatorTest(
     test_util.TempDirTestCase, dns_test_common.BaseAuthenticatorTest
 ):
     def setUp(self):
-        super(AuthenticatorTest, self).setUp()
-
         from certbot_dns_ionos.dns_ionos import Authenticator
+
+        super().setUp()
 
         path = os.path.join(self.tempdir, "file.ini")
         dns_test_common.write(
@@ -36,7 +36,6 @@ class AuthenticatorTest(
             path,
         )
 
-        super(AuthenticatorTest, self).setUp()
         self.config = mock.MagicMock(
             ionos_credentials=path, ionos_propagation_seconds=0
         )  # don't wait during tests
@@ -47,7 +46,8 @@ class AuthenticatorTest(
         # _get_ionos_client | pylint: disable=protected-access
         self.auth._get_ionos_client = mock.MagicMock(return_value=self.mock_client)
 
-    def test_perform(self):
+    @test_util.patch_display_util()
+    def test_perform(self, unused_mock_get_utility):
         self.auth.perform([self.achall])
 
         expected = [
@@ -63,8 +63,8 @@ class AuthenticatorTest(
         self.auth.cleanup([self.achall])
 
         expected = [
-            mock.call.del_txt_record(
-                DOMAIN, "_acme-challenge." + DOMAIN, mock.ANY, mock.ANY
+            mock.call.del_matching_records(
+                DOMAIN, "_acme-challenge." + DOMAIN
             )
         ]
         self.assertEqual(expected, self.mock_client.mock_calls)
@@ -105,7 +105,7 @@ class ionosClientTest(unittest.TestCase):
                 ]
             }
             m.register_uri('GET', 'mock://endpoint/dns/v1/zones/11af3414-ebba-11e9-8df5-66fbe8a334b4', status_code=200, reason="OK", json=mock_response)
-            m.register_uri('PUT', 'mock://endpoint/dns/v1/zones/11af3414-ebba-11e9-8df5-66fbe8a334b4/records/22af3414-abbe-9e11-5df5-66fbe8e334b4', status_code=200, reason="OK")
+            m.register_uri('PATCH', 'mock://endpoint/dns/v1/zones/11af3414-ebba-11e9-8df5-66fbe8a334b4', status_code=200, reason="OK")
             try:
                 self.client.add_txt_record(
                     DOMAIN, self.record_name, self.record_content, self.record_ttl
@@ -135,7 +135,7 @@ class ionosClientTest(unittest.TestCase):
                     DOMAIN, self.record_name, self.record_content, self.record_ttl
                 )
 
-    def test_del_txt_record(self):
+    def test_del_matching_records(self):
         with requests_mock.Mocker() as m:
             mock_response = [{
                 "id": "11af3414-ebba-11e9-8df5-66fbe8a334b4",
@@ -163,8 +163,8 @@ class ionosClientTest(unittest.TestCase):
             m.register_uri('GET', 'mock://endpoint/dns/v1/zones/11af3414-ebba-11e9-8df5-66fbe8a334b4', status_code=200, reason="OK", json=mock_response)
             m.register_uri('DELETE', 'mock://endpoint/dns/v1/zones/11af3414-ebba-11e9-8df5-66fbe8a334b4/records/22af3414-abbe-9e11-5df5-66fbe8e334b4', status_code=200, reason="OK")
             try:
-                self.client.del_txt_record(
-                    DOMAIN, self.record_name, self.record_content, self.record_ttl
+                self.client.del_matching_records(
+                    DOMAIN, self.record_name
                 )
             except:
                     self.fail("No exeption expected")

--- a/certbot_dns_ionos/dns_ionos_test.py
+++ b/certbot_dns_ionos/dns_ionos_test.py
@@ -1,6 +1,8 @@
 """Tests for certbot_dns_ionos.dns_ionos."""
 
 import unittest
+from uuid import uuid4
+from random import randint
 
 import mock
 import json
@@ -16,6 +18,12 @@ from certbot.tests import util as test_util
 FAKE_PREFIX = "prefix"
 FAKE_SECRET = "secret"
 FAKE_ENDPOINT = "mock://endpoint"
+
+FAKE_RECORD_NAME = "foo" + str(randint(10000, 99999))
+FAKE_RECORD_CONTENT = "bar" + str(randint(10000, 99999))
+FAKE_RECORD_TTL = 42
+FAKE_ZONE_ID = str(uuid4())
+FAKE_RECORD_ID = str(uuid4())
 
 
 class AuthenticatorTest(
@@ -71,10 +79,6 @@ class AuthenticatorTest(
 
 
 class ionosClientTest(unittest.TestCase):
-    record_name = "foo"
-    record_content = "bar"
-    record_ttl = 42
-
     def setUp(self):
         from certbot_dns_ionos.dns_ionos import _ionosClient
         self.client = _ionosClient(FAKE_ENDPOINT, FAKE_PREFIX, FAKE_SECRET)
@@ -82,18 +86,18 @@ class ionosClientTest(unittest.TestCase):
     def test_add_txt_record(self):
         with requests_mock.Mocker() as m:
             mock_response = [{
-                "id": "11af3414-ebba-11e9-8df5-66fbe8a334b4",
-                "name": "example.com",
+                "id": FAKE_ZONE_ID,
+                "name": DOMAIN,
                 "type": "NATIVE"}]
             m.register_uri('GET', 'mock://endpoint/dns/v1/zones', status_code=200, reason="OK", json=mock_response)
             mock_response = {
-                "id": "11af3414-ebba-11e9-8df5-66fbe8a334b4",
-                "name": "example.com",
+                "id": FAKE_ZONE_ID,
+                "name": DOMAIN,
                 "type": "NATIVE",
                 "records": [
                     {
-                    "id": "22af3414-abbe-9e11-5df5-66fbe8e334b4",
-                    "name": "foo",
+                    "id": FAKE_RECORD_ID,
+                    "name": FAKE_RECORD_NAME,
                     "rootName": "string",
                     "type": "TXT",
                     "content": "string",
@@ -104,25 +108,22 @@ class ionosClientTest(unittest.TestCase):
                     }
                 ]
             }
-            m.register_uri('GET', 'mock://endpoint/dns/v1/zones/11af3414-ebba-11e9-8df5-66fbe8a334b4', status_code=200, reason="OK", json=mock_response)
-            m.register_uri('PATCH', 'mock://endpoint/dns/v1/zones/11af3414-ebba-11e9-8df5-66fbe8a334b4', status_code=200, reason="OK")
-            try:
-                self.client.add_txt_record(
-                    DOMAIN, self.record_name, self.record_content, self.record_ttl
-                )
-            except:
-                self.fail("No exeption expected")
+            m.register_uri('GET', 'mock://endpoint/dns/v1/zones/' + FAKE_ZONE_ID, status_code=200, reason="OK", json=mock_response)
+            m.register_uri('PATCH', 'mock://endpoint/dns/v1/zones/' + FAKE_ZONE_ID, status_code=200, reason="OK")
+            self.client.add_txt_record(
+                DOMAIN, FAKE_RECORD_NAME, FAKE_RECORD_CONTENT, FAKE_RECORD_TTL
+            )
 
     def test_add_txt_record_fail_to_find_domain(self):
         with requests_mock.Mocker() as m:
             mock_response = [{
-                "id": "11af3414-ebba-11e9-8df5-66fbe8a334b4",
-                "name": "test.com",
+                "id": FAKE_ZONE_ID,
+                "name": "a-different-" + DOMAIN,
                 "type": "NATIVE"}]
             m.register_uri('GET', 'mock://endpoint/dns/v1/zones', status_code=200, reason="OK", json=mock_response)
             with self.assertRaises(errors.PluginError) as context:
                 self.client.add_txt_record(
-                    DOMAIN, self.record_name, self.record_content, self.record_ttl
+                    DOMAIN, FAKE_RECORD_NAME, FAKE_RECORD_CONTENT, FAKE_RECORD_TTL
                 )
 
     
@@ -132,24 +133,24 @@ class ionosClientTest(unittest.TestCase):
             m.register_uri('GET', 'mock://endpoint/dns/v1/zones', status_code=401, reason="Unauthorized", json=mock_response)
             with self.assertRaises(errors.PluginError) as context:
                 self.client.add_txt_record(
-                    DOMAIN, self.record_name, self.record_content, self.record_ttl
+                    DOMAIN, FAKE_RECORD_NAME, FAKE_RECORD_CONTENT, FAKE_RECORD_TTL
                 )
 
     def test_del_matching_records(self):
         with requests_mock.Mocker() as m:
             mock_response = [{
-                "id": "11af3414-ebba-11e9-8df5-66fbe8a334b4",
-                "name": "example.com",
+                "id": FAKE_ZONE_ID,
+                "name": DOMAIN,
                 "type": "NATIVE"}]
             m.register_uri('GET', 'mock://endpoint/dns/v1/zones', status_code=200, reason="OK", json=mock_response)
             mock_response = {
-                "id": "11af3414-ebba-11e9-8df5-66fbe8a334b4",
-                "name": "example.com",
+                "id": FAKE_ZONE_ID,
+                "name": DOMAIN,
                 "type": "NATIVE",
                 "records": [
                     {
-                    "id": "22af3414-abbe-9e11-5df5-66fbe8e334b4",
-                    "name": "foo",
+                    "id": FAKE_RECORD_ID,
+                    "name": FAKE_RECORD_NAME,
                     "rootName": "string",
                     "type": "TXT",
                     "content": "string",
@@ -160,15 +161,11 @@ class ionosClientTest(unittest.TestCase):
                     }
                 ]
             }
-            m.register_uri('GET', 'mock://endpoint/dns/v1/zones/11af3414-ebba-11e9-8df5-66fbe8a334b4', status_code=200, reason="OK", json=mock_response)
-            m.register_uri('DELETE', 'mock://endpoint/dns/v1/zones/11af3414-ebba-11e9-8df5-66fbe8a334b4/records/22af3414-abbe-9e11-5df5-66fbe8e334b4', status_code=200, reason="OK")
-            try:
-                self.client.del_matching_records(
-                    DOMAIN, self.record_name
-                )
-            except:
-                    self.fail("No exeption expected")
-
+            m.register_uri('GET', 'mock://endpoint/dns/v1/zones/' + FAKE_ZONE_ID, status_code=200, reason="OK", json=mock_response)
+            m.register_uri('DELETE', 'mock://endpoint/dns/v1/zones/' + FAKE_ZONE_ID + '/records/' + FAKE_RECORD_ID, status_code=200, reason="OK")
+            self.client.del_matching_records(
+                DOMAIN, FAKE_RECORD_NAME
+            )
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from setuptools import find_packages
 version = '2024.11.09'
 
 install_requires = [
-    "acme>=3.0.0",
-    "certbot>=3.0.0",
+    "acme>=2.9.0",
+    "certbot>=2.9.0",
     "setuptools",
     "requests",
 ]

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ install_requires = [
     "certbot>=3.0.0",
     "setuptools",
     "requests",
+]
+
+tests_require = [
     "mock",
     "requests-mock",
 ]
@@ -59,4 +62,7 @@ setup(
         ]
     },
     test_suite="certbot_dns_ionos",
+    extras_require={
+        "test": tests_require,
+    }
 )


### PR DESCRIPTION
_(intended to be stacked on top of #33)_

I have personally tested that this plugin works unmodified with
'certbot==2.9.0' and 'acme==2.9.0'.

Many still-popular Linux distributions include older versions of the Certbot
and ACME packages for Python.

For example, Ubuntu 24.04 (a "Long Term Support" release) includes v2.9.0:

- https://packages.ubuntu.com/noble/python3-certbot
- https://packages.ubuntu.com/noble/python3-acme

This allows the plugin to be installed with 'pip', without any
additional dependencies beyond what is already installed for the system-wide
installation of 'certbot'. This allows me to continue using the plugin
on my resource-constrained ultra-cheap IONOS VPS, which struggles to run
Docker.

## Summary by Sourcery

Relax Certbot/ACME version requirements and update tests and packaging to support Certbot 2.9.0 while exercising the DNS plugin in CI.

Enhancements:
- Adjust DNS client tests and expectations to reflect updated record management behaviour, including matching-record deletion and zone-level PATCH operations.
- Refine authenticator tests and setup to be compatible with a wider range of Certbot versions.

Build:
- Relax acme and certbot minimum versions to 2.9.0 and factor test dependencies into a dedicated extras_require group.

CI:
- Run the test suite as part of the Python publish workflow to validate releases before building artifacts.

Documentation:
- Document continued compatibility with Certbot 2.9.0 in the changelog.